### PR TITLE
Add a base help message when no argument is given

### DIFF
--- a/meliodas.py
+++ b/meliodas.py
@@ -1,4 +1,6 @@
 import argparse
+import sys
+
 from meliodas.parsers.create import create_parser
 from meliodas.parsers.list import list_parser
 
@@ -17,7 +19,11 @@ def main():
     parser_list.set_defaults(func=listCronJobs)
 
     args = parser.parse_args()
-    args.func(args)
+
+    if len(sys.argv) > 1:
+        args.func(args)
+    else:
+        parser.print_help()
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
When executing meliodas.py with no arguments, the interface would
fail due to an AttributeError because it was passing an empty
Namespace object to the functions.

In order to solve that, the 'sys' module was used to check the
arguments that were given and print a help message if no argument
is specified.